### PR TITLE
Added golangci-lint support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,87 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    # - bodyclose
+    - dogsled
+    # - errcheck
+    # - funlen
+    # - gochecknoinits
+    # - goconst
+    # - gocritic
+    # - gocyclo
+    # - gosec
+    # - govet
+    - ineffassign
+    # - lll
+    - misspell
+    - nakedret
+    # - staticcheck
+    - unconvert
+    # - unparam
+    # - unused
+    - whitespace
+  settings:
+    funlen:
+      lines: 200 # TODO: make it 120
+      statements: 60
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+        - paramTypeCombine
+        - sloppyReassign
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+        - experimental
+      settings:
+        hugeParam:
+          sizeThreshold: 256
+        rangeValCopy:
+          sizeThreshold: 256
+    gocyclo:
+      min-complexity: 25
+    lll:
+      line-length: 200 # TODO: make it 140 and fix linter errors
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - dogsled
+          - funlen
+          - goconst
+          - gocritic
+          - gocyclo
+          - gosec
+          - govet
+          - ineffassign
+          - lll
+          - staticcheck
+          - unparam
+          - unused
+          - staticcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    # - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/hypernetix/hyperspot/
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/libs/api/api_logger.go
+++ b/libs/api/api_logger.go
@@ -25,7 +25,6 @@ func logAPIRequest(req *http.Request) {
 	// Only log body if debug level is enabled and it's not a file upload
 	if logger.ConsoleLevel >= logging.DebugLevel ||
 		logger.FileLevel >= logging.DebugLevel {
-
 		// Skip body logging for file uploads (multipart/form-data)
 		contentType := req.Header.Get("Content-Type")
 		isFileUpload := contentType != "" && strings.HasPrefix(contentType, "multipart/form-data")

--- a/libs/utils/tempfile_test.go
+++ b/libs/utils/tempfile_test.go
@@ -37,20 +37,20 @@ func TestSaveUploadedTempFile(t *testing.T) {
 
 		// Call the function
 		tempPath, err := SaveUploadedTempFile(testFile, "", testFilename)
-		
+
 		// Assertions
 		require.NoError(t, err)
 		defer os.Remove(tempPath) // Clean up
-		
+
 		// Verify file was created
 		assert.FileExists(t, tempPath)
-		
+
 		// Verify file extension
 		assert.Equal(t, ".txt", filepath.Ext(tempPath))
-		
+
 		// Verify file name pattern
 		assert.True(t, strings.Contains(filepath.Base(tempPath), "hyperspot_upload_"))
-		
+
 		// Verify file content
 		content, err := os.ReadFile(tempPath)
 		require.NoError(t, err)
@@ -63,25 +63,25 @@ func TestSaveUploadedTempFile(t *testing.T) {
 		customTempDir, err := os.MkdirTemp("", "hyperspot_test_*")
 		require.NoError(t, err)
 		defer os.RemoveAll(customTempDir) // Clean up
-		
+
 		// Create test data
 		testContent := "custom temp dir test content"
 		testFile := createTestMultipartFile(testContent)
 		testFilename := "custom_test.pdf"
-		
+
 		// Call the function
 		tempPath, err := SaveUploadedTempFile(testFile, customTempDir, testFilename)
-		
+
 		// Assertions
 		require.NoError(t, err)
-		
+
 		// Verify file was created in the custom directory
 		assert.FileExists(t, tempPath)
 		assert.Equal(t, customTempDir, filepath.Dir(tempPath))
-		
+
 		// Verify file extension
 		assert.Equal(t, ".pdf", filepath.Ext(tempPath))
-		
+
 		// Verify file content
 		content, err := os.ReadFile(tempPath)
 		require.NoError(t, err)
@@ -93,14 +93,14 @@ func TestSaveUploadedTempFile(t *testing.T) {
 		testContent := "no extension file"
 		testFile := createTestMultipartFile(testContent)
 		testFilename := "no_extension_file"
-		
+
 		tempPath, err := SaveUploadedTempFile(testFile, "", testFilename)
 		require.NoError(t, err)
 		defer os.Remove(tempPath)
-		
+
 		assert.FileExists(t, tempPath)
 		assert.Equal(t, "", filepath.Ext(tempPath))
-		
+
 		content, err := os.ReadFile(tempPath)
 		require.NoError(t, err)
 		assert.Equal(t, testContent, string(content))
@@ -110,10 +110,10 @@ func TestSaveUploadedTempFile(t *testing.T) {
 	t.Run("ErrorCreatingTempFile", func(t *testing.T) {
 		testFile := createTestMultipartFile("error test")
 		testFilename := "test.txt"
-		
+
 		// Use a non-existent directory to force an error
 		nonExistentDir := "/non/existent/directory"
-		
+
 		_, err := SaveUploadedTempFile(testFile, nonExistentDir, testFilename)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create temporary file")
@@ -124,7 +124,7 @@ func TestSaveUploadedTempFile(t *testing.T) {
 		// Create a mock multipart file that fails on read
 		testFile := &mockFailingMultipartFile{}
 		testFilename := "failing.txt"
-		
+
 		_, err := SaveUploadedTempFile(testFile, "", testFilename)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to copy file content")


### PR DESCRIPTION
1. Fix the lint issues
2. Added .golangci.yml file

To check the lint use:

```
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.2.1
golangci-lint ./...
```